### PR TITLE
Put m1, t0, b0 into the nat objects

### DIFF
--- a/src/bench/scala/io/typechecked/numerology/ternary/BenchmarkMult.scala
+++ b/src/bench/scala/io/typechecked/numerology/ternary/BenchmarkMult.scala
@@ -2,6 +2,8 @@ package io.typechecked
 package numerology
 package ternary
 
+import io.typechecked.numerology.ternary.TNat.t0
+
 object BenchmarkMult {
 
   def mult[M <: TNat, N <: TNat](implicit m: Mult[M, N]): m.Out = ???

--- a/src/main/scala/io/typechecked/numerology/binary/BNat.scala
+++ b/src/main/scala/io/typechecked/numerology/binary/BNat.scala
@@ -6,7 +6,6 @@ sealed trait BNat
 
 sealed trait BNonZero extends BNat
 
-final class b0 extends BNat
 
 trait BOperation[N <: BNat] extends BNonZero
 
@@ -14,6 +13,8 @@ trait One[T <: BNat] extends BOperation[T]
 trait Zero[T <: BNat] extends BOperation[T]
 
 object BNat {
+
+  final class b0 extends BNat
 
   type b1 = One[b0]
   type b2 = Zero[One[b0]]

--- a/src/main/scala/io/typechecked/numerology/binary/Incr.scala
+++ b/src/main/scala/io/typechecked/numerology/binary/Incr.scala
@@ -2,7 +2,7 @@ package io.typechecked
 package numerology
 package binary
 
-import BNat.b1
+import BNat.{b0, b1}
 
 trait Incr[A <: BNat] { type Out <: BNat }
 

--- a/src/main/scala/io/typechecked/numerology/binary/Mult.scala
+++ b/src/main/scala/io/typechecked/numerology/binary/Mult.scala
@@ -2,7 +2,7 @@ package io.typechecked
 package numerology
 package binary
 
-import BNat.b1
+import BNat.{b0, b1}
 
 trait Mult[A <: BNat, B <: BNat] { type Out <: BNat }
 

--- a/src/main/scala/io/typechecked/numerology/binary/Sum.scala
+++ b/src/main/scala/io/typechecked/numerology/binary/Sum.scala
@@ -2,6 +2,8 @@ package io.typechecked
 package numerology
 package binary
 
+import BNat.b0
+
 trait Sum[A <: BNat, B <: BNat] { type Out <: BNat }
 
 object Sum {

--- a/src/main/scala/io/typechecked/numerology/binary/ToLong.scala
+++ b/src/main/scala/io/typechecked/numerology/binary/ToLong.scala
@@ -2,6 +2,8 @@ package io.typechecked
 package numerology
 package binary
 
+import BNat.b0
+
 trait ToLong[T <: BNat] { def value: Long }
 
 object ToLong {

--- a/src/main/scala/io/typechecked/numerology/binary/UnsafeToInt.scala
+++ b/src/main/scala/io/typechecked/numerology/binary/UnsafeToInt.scala
@@ -2,6 +2,8 @@ package io.typechecked
 package numerology
 package binary
 
+import BNat.b0
+
 // If provided a BNat > MaxInt it will overflow and wrap around
 // It is faster than ToInt though
 // Only use if you're sure you will never exceed MaxInt

--- a/src/main/scala/io/typechecked/numerology/binary/comparisons.scala
+++ b/src/main/scala/io/typechecked/numerology/binary/comparisons.scala
@@ -2,6 +2,8 @@ package io.typechecked
 package numerology
 package binary
 
+import BNat.b0
+
 // Less than
 trait Lt[A <: BNat, B <: BNat]
 

--- a/src/main/scala/io/typechecked/numerology/primary/Concat.scala
+++ b/src/main/scala/io/typechecked/numerology/primary/Concat.scala
@@ -2,6 +2,8 @@ package io.typechecked
 package numerology
 package primary
 
+import MNat.m1
+
 trait Concat[A <: MNat, B <: MNat] { type Out <: MNat }
 
 object Concat {

--- a/src/main/scala/io/typechecked/numerology/primary/GCD.scala
+++ b/src/main/scala/io/typechecked/numerology/primary/GCD.scala
@@ -4,6 +4,7 @@ package primary
 
 import shapeless.=:!=
 
+import MNat.m1
 import ternary.Lt
 import ternary.TNonZero
 

--- a/src/main/scala/io/typechecked/numerology/primary/MNat.scala
+++ b/src/main/scala/io/typechecked/numerology/primary/MNat.scala
@@ -12,8 +12,6 @@ import Prime._
  */
 sealed trait MNat
 
-final class m1 extends MNat
-
 sealed trait PrimePower
 trait ^[Pr <: Prime, Po <: TNonZero] extends PrimePower
 
@@ -21,6 +19,8 @@ trait Compound extends MNat
 trait *:[P <: ^[_, _], N <: MNat] extends MNat with Compound
 
 object MNat {
+
+  final class m1 extends MNat
 
   type m2 = (p2 ^ t1) *: m1
   type m3 = (p3 ^ t1) *: m1

--- a/src/main/scala/io/typechecked/numerology/primary/PartitionAndSimplify.scala
+++ b/src/main/scala/io/typechecked/numerology/primary/PartitionAndSimplify.scala
@@ -2,6 +2,7 @@ package io.typechecked
 package numerology
 package primary
 
+import MNat.m1
 import ternary.Sum
 import ternary.TNat._
 import ternary.TNonZero

--- a/src/main/scala/io/typechecked/numerology/primary/Sorted.scala
+++ b/src/main/scala/io/typechecked/numerology/primary/Sorted.scala
@@ -2,6 +2,7 @@ package io.typechecked
 package numerology
 package primary
 
+import MNat.m1
 import ternary.TNat._
 import ternary.TNonZero
 

--- a/src/main/scala/io/typechecked/numerology/primary/mult/Mult2.scala
+++ b/src/main/scala/io/typechecked/numerology/primary/mult/Mult2.scala
@@ -3,6 +3,7 @@ package numerology
 package primary
 package mult
 
+import io.typechecked.numerology.primary.MNat.m1
 import ternary.TNat
 import ternary.TNonZero
 import shapeless.=:!=

--- a/src/main/scala/io/typechecked/numerology/primary/mult/Mult3.scala
+++ b/src/main/scala/io/typechecked/numerology/primary/mult/Mult3.scala
@@ -3,6 +3,7 @@ package numerology
 package primary
 package mult
 
+import MNat.m1
 import ternary.AsNonZero
 import ternary.TNat
 import ternary.TNonZero

--- a/src/main/scala/io/typechecked/numerology/ternary/Incr.scala
+++ b/src/main/scala/io/typechecked/numerology/ternary/Incr.scala
@@ -2,7 +2,7 @@ package io.typechecked
 package numerology
 package ternary
 
-import TNat.t1
+import TNat.{t0, t1}
 
 trait Incr[A <: TNat] { type Out <: TNat }
 

--- a/src/main/scala/io/typechecked/numerology/ternary/IsEven.scala
+++ b/src/main/scala/io/typechecked/numerology/ternary/IsEven.scala
@@ -2,6 +2,8 @@ package io.typechecked
 package numerology
 package ternary
 
+import TNat.t0
+
 trait IsEven[M <: TNat]
 
 object IsEven {

--- a/src/main/scala/io/typechecked/numerology/ternary/Length.scala
+++ b/src/main/scala/io/typechecked/numerology/ternary/Length.scala
@@ -2,6 +2,8 @@ package io.typechecked
 package numerology
 package ternary
 
+import TNat.t0
+
 trait Length[M <: TNat] { type Out <: TNat }
 
 object Length {

--- a/src/main/scala/io/typechecked/numerology/ternary/Minus.scala
+++ b/src/main/scala/io/typechecked/numerology/ternary/Minus.scala
@@ -2,6 +2,8 @@ package io.typechecked
 package numerology
 package ternary
 
+import TNat.t0
+
 trait Minus[A <: TNat, B <: TNat] { type Out <: TNat }
 
 object Minus {

--- a/src/main/scala/io/typechecked/numerology/ternary/Mult.scala
+++ b/src/main/scala/io/typechecked/numerology/ternary/Mult.scala
@@ -2,6 +2,8 @@ package io.typechecked
 package numerology
 package ternary
 
+import TNat.t0
+
 trait Mult[A <: TNat, B <: TNat] { type Out <: TNat }
 
 object Mult {

--- a/src/main/scala/io/typechecked/numerology/ternary/Sum.scala
+++ b/src/main/scala/io/typechecked/numerology/ternary/Sum.scala
@@ -2,6 +2,8 @@ package io.typechecked
 package numerology
 package ternary
 
+import io.typechecked.numerology.ternary.TNat.t0
+
 trait Sum[A <: TNat, B <: TNat] { type Out <: TNat }
 
 object Sum {

--- a/src/main/scala/io/typechecked/numerology/ternary/TNat.scala
+++ b/src/main/scala/io/typechecked/numerology/ternary/TNat.scala
@@ -4,9 +4,6 @@ package ternary
 
 sealed trait TNat
 
-// 0
-final class t0 extends TNat
-
 // Positive int -- TODO Could replace with implicit =:!= t0
 sealed trait TNonZero extends TNat
 
@@ -18,6 +15,9 @@ trait One[T <: TNat] extends TOperation[T]    // One[t] = 3t + 1
 trait Two[T <: TNat] extends TOperation[T]    // Two[t] = 3t + 2
 
 object TNat {
+
+  final class t0 extends TNat
+
   type t1 = One[t0]
   type t2 = Two[t0]
   type t3 = Zero[One[t0]]

--- a/src/main/scala/io/typechecked/numerology/ternary/ToBigInt.scala
+++ b/src/main/scala/io/typechecked/numerology/ternary/ToBigInt.scala
@@ -2,6 +2,8 @@ package io.typechecked
 package numerology
 package ternary
 
+import TNat.t0
+
 // Slowest way to get a number value from a TNat but is always safe
 trait ToBigInt[T <: TNat] { def value: BigInt }
 

--- a/src/main/scala/io/typechecked/numerology/ternary/Treble.scala
+++ b/src/main/scala/io/typechecked/numerology/ternary/Treble.scala
@@ -2,6 +2,8 @@ package io.typechecked
 package numerology
 package ternary
 
+import TNat.t0
+
 trait Treble[M <: TNat] { type Out <: TNat }
 
 object Treble {

--- a/src/main/scala/io/typechecked/numerology/ternary/UnsafeToInt.scala
+++ b/src/main/scala/io/typechecked/numerology/ternary/UnsafeToInt.scala
@@ -2,6 +2,8 @@ package io.typechecked
 package numerology
 package ternary
 
+import TNat.t0
+
 // If provided a TNat > MaxInt it will overflow and wrap around
 // It is faster than ToInt though
 // Only use if you're sure you will never exceed MaxInt

--- a/src/main/scala/io/typechecked/numerology/ternary/UnsafeToLong.scala
+++ b/src/main/scala/io/typechecked/numerology/ternary/UnsafeToLong.scala
@@ -2,6 +2,7 @@ package io.typechecked
 package numerology
 package ternary
 
+import TNat.t0
 
 // If provided a TNat > MaxLong it will overflow and wrap around
 // It is faster than ToLong though

--- a/src/main/scala/io/typechecked/numerology/ternary/comparisons.scala
+++ b/src/main/scala/io/typechecked/numerology/ternary/comparisons.scala
@@ -2,7 +2,7 @@ package io.typechecked
 package numerology
 package ternary
 
-import TNat.t1
+import TNat.{t0, t1}
 
 // Less than
 trait Lt[A <: TNat, B <: TNat]


### PR DESCRIPTION
To be more consistent. They were left out of them due to laziness